### PR TITLE
Removed unused constructor to fix clang compile error

### DIFF
--- a/q_lib/include/q/fx/moving_average.hpp
+++ b/q_lib/include/q/fx/moving_average.hpp
@@ -45,11 +45,6 @@ namespace cycfi { namespace q
          _buff.clear();
       }
 
-      moving_average(duration d, std::size_t sps)
-       : moving_average(std::size_t(sps * float(d)))
-      {
-      }
-
       T operator()(T s)
       {
          _sum += s;              // Add the latest sample to the sum


### PR DESCRIPTION
Compile error was:
```
In file included from Client/Source/Tuner.cpp:14:
In file included from Client/../third_party/Q/q_lib/include/q/pitch/pitch_detector.hpp:9:
Client/../third_party/Q/q_lib/include/q/fx/moving_average.hpp:50:43: error: cannot convert 'cycfi::duration'
      (aka 'duration<double>') to 'float' without a conversion operator
       : moving_average(std::size_t(sps * float(d)))
                                          ^~~~~~~
```